### PR TITLE
add_comment

### DIFF
--- a/app/assets/javascripts/comments.coffee
+++ b/app/assets/javascripts/comments.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the comments controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/items/index.scss
+++ b/app/assets/stylesheets/items/index.scss
@@ -8,6 +8,11 @@
   &__header {
     background-color: #ffffff;
     border-bottom: 1px solid #3ccace;
+    .header_flash {
+      background-color: red;
+      color: white;
+      text-align: center;
+    }
 
     .contents {
       max-width: 1040px;

--- a/app/assets/stylesheets/items/show.scss
+++ b/app/assets/stylesheets/items/show.scss
@@ -16,7 +16,7 @@
   background: whitesmoke;
   &__container {
     width: 700px;
-    margin: 40px auto 0;
+    margin: 40px auto;
     background-color: white;
     &__item {
       padding: 25px 40px 40px;

--- a/app/assets/stylesheets/items/show.scss
+++ b/app/assets/stylesheets/items/show.scss
@@ -281,6 +281,13 @@
   background-color: white;
   .message-content {
     padding: 20px;
+    .message_error {
+      background-color: red;
+      width:100%;
+      margin:20px 0;
+      padding:10px;
+      color: white;
+    }
     .guest-message-box {
       .message-user{
         text-decoration: none;

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,21 @@
+class CommentsController < ApplicationController
+
+  def create
+    comment = Comment.new(comment_params)
+    if comment.save
+      redirect_to item_path(params[:item_id])  
+    else
+      # @categories = Category.where(ancestry: nil)
+      # @item = Item.find(params[:item_id])
+      # @items = @item.user.items
+      # @comment = Comment.new
+      # render template: "items/show"
+    end
+end
+
+  private
+  def comment_params
+    params.require(:comment).permit(:comment).merge( item_id:params[:item_id], user_id:current_user.id)
+  end
+
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,21 +1,20 @@
 class CommentsController < ApplicationController
 
+  rescue_from ActiveRecord::RecordInvalid , with: :comment_error_check
+  
   def create
     comment = Comment.new(comment_params)
-    if comment.save
-      redirect_to item_path(params[:item_id])  
-    else
-      # @categories = Category.where(ancestry: nil)
-      # @item = Item.find(params[:item_id])
-      # @items = @item.user.items
-      # @comment = Comment.new
-      # render template: "items/show"
-    end
-end
+    comment.save!
+    redirect_to item_path(params[:item_id])
+  end
 
   private
   def comment_params
     params.require(:comment).permit(:comment).merge( item_id:params[:item_id], user_id:current_user.id)
+  end
+
+  def comment_error_check(event)
+    redirect_to item_path(params[:item_id]), notice: event.message
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,6 +29,8 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @comment = Comment.new
+    @comments = @item.comments.includes(:user)
   end
 
   def edit

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,8 @@
+class Comment < ApplicationRecord
+
+  belongs_to :user
+  belongs_to :item
+
+  validates :comment, presence: true
+
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,6 +8,7 @@ class Item < ApplicationRecord
   belongs_to :brand, optional: true
   belongs_to_active_hash :prefecture
   belongs_to_active_hash :post_way
+  has_many :comments
 
   enum pay_side: { seller: 1, buyer: 2 }
   enum post_date: { shortest: 1, normal: 2, longest: 3 }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ApplicationRecord
   belongs_to :brand, optional: true
   belongs_to_active_hash :prefecture
   belongs_to_active_hash :post_way
-  has_many :comments
+  has_many :comments , dependent: :destroy
 
   enum pay_side: { seller: 1, buyer: 2 }
   enum post_date: { shortest: 1, normal: 2, longest: 3 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,4 +23,6 @@ class User < ApplicationRecord
 
   has_one :address, dependent: :destroy
   has_many :cards, dependent: :destroy
+  has_many :comments
+  has_many :items
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,6 @@ class User < ApplicationRecord
 
   has_one :address, dependent: :destroy
   has_many :cards, dependent: :destroy
-  has_many :comments
-  has_many :items
+  has_many :comments, dependent: :destroy
+  has_many :items, dependent: :destroy
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -92,83 +92,49 @@
             =link_to "#", class: "like-report-btn" do
               %i.fas.fa-lock
               %span あんしん・あんぜんへの取り組み
-  .item-detail-message
-    .message-container
-      .message-content
-        %ul.guest-message-box
-          = link_to "#", class: "message-user" do
-            .message-user__thumbnail
-              =image_tag 'https://static.mercdn.net/images/member_photo_noimage_thumb.png'
-            .user_name
-              Taro
-          %li.guest-message-item.clearfix
-            .message-box
-              .message-box__text
-                めっちゃ欲しいです！
-        %ul.guest-message-box
-          = link_to "#", class: "message-user" do
-            .message-user__thumbnail
-              =image_tag 'https://static.mercdn.net/images/member_photo_noimage_thumb.png'
-            .user_name
-              Saburo
-          %li.guest-message-item.clearfix
-            .message-box
-              .message-box__text
-                値下げできますか？
-        %ul.guest-message-box
-          = link_to "#", class: "message-user" do
-            .message-user__thumbnail
-              =image_tag 'https://static.mercdn.net/images/member_photo_noimage_thumb.png'
-            .user_name
-              Siro
-          %li.guest-message-item.clearfix
-            .message-box
-              .message-box__text
-                もう少し細かい写真はありますか？
-        %ul.guest-message-box
-          = link_to "#", class: "message-user" do
-            .message-user__thumbnail
-              =image_tag 'https://static.mercdn.net/images/member_photo_noimage_thumb.png'
-            .user_name
-              Goro
-          %li.guest-message-item.clearfix
-            .message-box
-              .message-box__text
-                いつ頃購入されましたか？
-        %ul.guest-message-box
-          = link_to "#", class: "message-user" do
-            .message-user__thumbnail
-              =image_tag 'https://images-na.ssl-images-amazon.com/images/I/71ffpermWIL._AC_SX522_.jpg'
-            .user_name
-              Jiro
-          %li.guest-message-item.clearfix
-            .message-box
-              .message-box__text
-                値下げはできません！写真はありません！購入日は覚えてません！
-      .message-content
-        = form_with(model: @item, local: true) do |f|
-          %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
-          = f.text_area :message, class: "message_text_area", maxlength: "100", cols: "60", required: true
-          = f.submit "コメントする", class: "message-btn"
-  %ul.nav-prev-next-box.clearfix
-    %li.nav-prev-next-box__left
-      = link_to "#" do
-        %i.fa.fa-angle-left
-        前の商品名
-    %li.nav-prev-next-box__right
-      = link_to "#" do
-        次の商品
-        %i.fa.fa-angle-right
-  .sns-content
-    .sns-content__icon-box
-      = link_to "#", class: "icon-btn icon-btn__facebook" do
-        %i.fab.fa-facebook-square
-      = link_to "#", class: "icon-btn icon-btn__twitter" do
-        %i.fab.fa-twitter-square
-      = link_to "#", class: "icon-btn icon-btn__line" do
-        %i.fab.fa-line
-      = link_to "#", class: "icon-btn icon-btn__pinterest" do
-        %i.fab.fa-pinterest-square
+    - if user_signed_in?
+      .item-detail-message
+        .message-container
+          - if @comments.present?
+            .message-content
+              - @comments.each do |comment_info|
+                %ul.guest-message-box
+                  = link_to "#", class: "message-user" do
+                    .message-user__thumbnail
+                      - if comment_info.user.image.present?
+                        = image_tag comment_info.user.image.url
+                      - else 
+                        = image_tag "icon/member_photo_noimage_thumb.png"
+                    .user_name
+                      = comment_info.user.nickname
+                  %li.guest-message-item.clearfix
+                    .message-box
+                      .message-box__text
+                        = comment_info.comment
+          .message-content
+            = form_with(model:[@item,@comment], local: true) do |f|
+              %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
+              = f.text_area :comment, class: "message_text_area", maxlength: "100", cols: "60", required: true
+              = f.submit "コメントする", class: "message-btn"
+    %ul.nav-prev-next-box.clearfix
+      %li.nav-prev-next-box__left
+        = link_to "#" do
+          %i.fa.fa-angle-left
+          前の商品名
+      %li.nav-prev-next-box__right
+        = link_to "#" do
+          次の商品
+          %i.fa.fa-angle-right
+    .sns-content
+      .sns-content__icon-box
+        = link_to "#", class: "icon-btn icon-btn__facebook" do
+          %i.fab.fa-facebook-square
+        = link_to "#", class: "icon-btn icon-btn__twitter" do
+          %i.fab.fa-twitter-square
+        = link_to "#", class: "icon-btn icon-btn__line" do
+          %i.fab.fa-line
+        = link_to "#", class: "icon-btn icon-btn__pinterest" do
+          %i.fab.fa-pinterest-square
   .items-container
     %h2.item-box-head
       = link_to @item.user do

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -112,9 +112,9 @@
                       .message-box__text
                         = comment_info.comment
           .message-content
+            %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
             = form_with(model:[@item,@comment], local: true) do |f|
-              %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
-              = f.text_area :comment, class: "message_text_area", maxlength: "100", cols: "60", required: true
+              = f.text_area :comment, class: "message_text_area", maxlength: "100", cols: "60"
               = f.submit "コメントする", class: "message-btn"
     %ul.nav-prev-next-box.clearfix
       %li.nav-prev-next-box__left
@@ -167,5 +167,5 @@
       %br 本当に削除しますか？
     .button-box.clearfix
       %button.cancel-btn.js-modal-close キャンセル
-      = link_to "削除する", item_path, method: :delete, class: "delete-btn"
+      = link_to "削除する", item_path(@item.id), method: :delete, class: "delete-btn"
 

--- a/app/views/templates/_header.html.haml
+++ b/app/views/templates/_header.html.haml
@@ -29,3 +29,6 @@
           %li
             = link_to "ログイン", new_user_session_path
             = link_to "新規会員登録", new_user_registration_path
+  .header_flash
+    - if flash[:notice]
+      = flash[:notice]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   # 購入確認ページに飛ぶ
   resources :items do
     resources :buys, only: [:new,:create]
+    resources :comments, only: [:create]
   end
 
   # カテゴリ機能に使用

--- a/db/migrate/20200602022229_create_comments.rb
+++ b/db/migrate/20200602022229_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :comments do |t|
+      t.text :comment,     null:false
+      t.integer :user_id,  foreign_key: true
+      t.integer :item_id,  foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_24_054849) do
+ActiveRecord::Schema.define(version: 2020_06_02_022229) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "zipcode", default: "", null: false
@@ -46,6 +46,14 @@ ActiveRecord::Schema.define(version: 2020_05_24_054849) do
     t.index ["ancestry"], name: "index_categories_on_ancestry"
   end
 
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "comment", null: false
+    t.integer "user_id"
+    t.integer "item_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "image", null: false
     t.integer "item_id"
@@ -66,6 +74,11 @@ ActiveRecord::Schema.define(version: 2020_05_24_054849) do
     t.integer "category_id"
     t.integer "user_id"
     t.integer "situation", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "post_ways", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,11 +78,6 @@ ActiveRecord::Schema.define(version: 2020_06_02_022229) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "post_ways", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", null: false

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :comment do
+    
+  end
+end

--- a/spec/helpers/comments_helper_spec.rb
+++ b/spec/helpers/comments_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CommentsHelper. For example:
+#
+# describe CommentsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CommentsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/comments_request_spec.rb
+++ b/spec/requests/comments_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Comments", type: :request do
+
+end


### PR DESCRIPTION
# Why
商品へのコメント・質問機能を実装するため

# What
以下のようにコメントの登録、表示ができるようにした。
![画面収録 2020-06-02 13 37 19 mov](https://user-images.githubusercontent.com/63713236/83480444-60127380-a4d6-11ea-9aa9-3e81a429d7c4.gif)

エラーハンドリング を追加（コメント無記入の場合）

![](https://i.gyazo.com/6cbb76e2e9df04bbc4652bb0ceac1dbe.png)

