### PR TITLE
出品者の売却済み商品ページ表示の修正

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -83,7 +83,7 @@
         - else @item.pay_side == "buyer"
           %span.item-tax
             (税込)
-      - if user_signed_in? && current_user.id == @item.user_id
+      - if user_signed_in? && current_user.id == @item.user_id && @item.situation == "exhibition"
         .item-explanation
           %p.item-explanation__box
             = safe_join(@item.detail.split("\n"),tag(:br))


### PR DESCRIPTION
# What
出品者が売却済みの商品詳細ページへ入った時の表示を修正
"編集ボタン等"の表示をなくし、"売り切れました"の表示
https://gyazo.com/de43f10bc2885e1c011c2b4f90292d4f
https://gyazo.com/20e46d90f640740e526885d06301f7c6
# Why
売却済み商品の編集等の機能は必要ないため