### PR TITLE
update修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -48,7 +48,8 @@ class ItemsController < ApplicationController
   end
 
   def update
-    if keep_or_update_images(item_params[:images_attributes]).present? && keep_or_update_images(item_params[:images_attributes]).length <= 10 
+    images = keep_or_update_images(item_params[:images_attributes])
+    if images.present? && images.length <= 10 
       brand = Brand.find_or_create_by(name:params[:item][:brand])
       brand_id = @item.brand&.id if brand.name.blank?
       @item.brand_id = brand&.id


### PR DESCRIPTION
what
登録されたItem(id)がなければTOPページへ
set_item
更新時削除しない・新規登録の画像があるか判断するメソッドを追加
keep_or_update_images
createアクションの分岐をreturnへ変更
why
登録していないItemのid を指定してもエラーページにならないように
画像なし・11枚以上で登録できないように
create時10枚以上登録できないように修正（コントローラー）
存在しないidを指定した時TOPページへリダイレクト
![noidtotop](https://user-images.githubusercontent.com/63630440/84173211-eec75780-aab7-11ea-8f01-6c4de671b461.gif)


画像を一枚も登録しないで更新すると編集ページへレンダー
![更新時画像なしrenderされる](https://user-images.githubusercontent.com/63630440/84172477-06eaa700-aab7-11ea-9446-68b31a8dcdb4.gif)
